### PR TITLE
Add option to pass a codec engine to the client

### DIFF
--- a/client-pool.js
+++ b/client-pool.js
@@ -19,6 +19,8 @@ function ClientPool(options) {
     authKey: this.authKey
   };
 
+  clientConnectOptions.codecEngine = options.codecEngine || null
+
   this._handleClientError = (event) => {
     this.emit('error', event);
   };

--- a/cluster-broker-client.js
+++ b/cluster-broker-client.js
@@ -14,6 +14,7 @@ function ClusterBrokerClient(broker, options) {
   this.mappingEngine = options.mappingEngine || 'skeletonRendezvous';
   this.clientPoolSize = options.clientPoolSize || 1;
   this.isReady = false;
+  this.codecEngine = options.codecEngine || null;
 
   if (this.mappingEngine === 'skeletonRendezvous') {
     this.mapper = new SkeletonRendezvousMapper(options.mappingEngineOptions);
@@ -67,7 +68,8 @@ ClusterBrokerClient.prototype.setBrokers = function (sccBrokerURIList) {
     let clientPool = new ClientPool({
       clientCount: this.clientPoolSize,
       targetURI: clientURI,
-      authKey: this.authKey
+      authKey: this.authKey,
+      codecEngine: this.codecEngine
     });
     brokerClientMap[clientURI] = clientPool;
     this.sccBrokerClientPools[clientURI] = clientPool;

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports.attach = function (broker, options) {
     authKey: authKey,
     mappingEngine: options.mappingEngine,
     clientPoolSize: options.clientPoolSize,
+    codecEngine: options.codecEngine,
   });
 
   let retryDelay = options.brokerRetryDelay || DEFAULT_RETRY_DELAY;


### PR DESCRIPTION
Using a custom codec engine is supported for socketcluster clients communicating to worker instances, but there's no way to specify a codec for use between the workers and the broker instances.

There are performance implications here, but in our case the default codec was actually breaking communication with clients.

This is a small change to allow callers to override the codec engine for socketcluster server/worker communication with the broker. For things to work correctly, you also need to specific this same codec on the [broker itself](https://github.com/SocketCluster/scc-broker).